### PR TITLE
fix: react script CI

### DIFF
--- a/templates/reactjs-boilerplate/package.json
+++ b/templates/reactjs-boilerplate/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "CI=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
- Treating warnings as errors because process.env.CI = true 