### PR TITLE
fix(htmx-minimal): Remove dependencies install

### DIFF
--- a/templates/htmx-minimal/.github/workflows/main.yml
+++ b/templates/htmx-minimal/.github/workflows/main.yml
@@ -22,9 +22,6 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install NPM dependencies
-        run: npm i
-        
       - name: Install Azion CLI
         run: |
           curl -o azionlinux https://downloads.azion.com/linux/x86_64/azion


### PR DESCRIPTION
The HTMX Minimal template has no dependencies, therefore it doesn't need a dependency install step in the workflow.