### PR TITLE
fix(turso-templates): remove link to doc

### DIFF
--- a/templates/nextjs-app-13-5-6-turso/app/turso/route.ts
+++ b/templates/nextjs-app-13-5-6-turso/app/turso/route.ts
@@ -50,9 +50,6 @@ export async function GET(request: NextRequest) {
                 <div class="instructions">
                     <h4>This is an example for creating, retrieving, updating and deleting items in a Turso DB table called Posts.</h4>
                 </div>
-                <div class="instructions">
-                  <p>This template requires a Turso database and table to work. Go to the <a href="https://www.azion.com/en/documentation/products/guides/nextjs-app-configurations-turso/" id="doclink">documentation</a> for more details.</p>
-              </div>
                 <div class="control">
                     <button id="btn-new-post" onclick="createItemElement()">
                             <i class="icons" data-lucide="message-square-plus"></i>
@@ -200,7 +197,7 @@ export async function GET(request: NextRequest) {
             } 
             await getMessage();
             document.getElementById("btn-new-post").removeAttribute('disabled');
-            alert("You have successfully saved your post to your collection!")
+            alert("You have successfully saved your post to your database!")
         }
 
         async function deleteItem(element, id) {

--- a/templates/turso-starter-kit/src/lib/html/index.js
+++ b/templates/turso-starter-kit/src/lib/html/index.js
@@ -48,9 +48,6 @@ export const indexHTML = () => {
                   <div class="instructions">
                       <h4>This is an example for creating, retrieving, updating and deleting items in a Turso DB table called Posts.</h4>
                   </div>
-                  <div class="instructions">
-                      <p>This template requires a Turso database and table to work. Go to the <a href="https://www.azion.com/en/documentation/products/guides/turso-starter-kit/" id="doclink">documentation</a> for more details.</p>
-                  </div>
                   <div class="control">
                       <button id="btn-new-post" onclick="createItemElement()">
                             <i class="icons" data-lucide="message-square-plus"></i>
@@ -198,7 +195,7 @@ export const indexHTML = () => {
               } 
               await getMessage();
               document.getElementById("btn-new-post").removeAttribute('disabled');
-              alert("You have successfully saved your post to your collection!")
+              alert("You have successfully saved your post to your database!")
           }
   
           async function deleteItem(element, id) {


### PR DESCRIPTION
The reference to the docs is not needed anymore, as now a new database is auto-deployed when the template is launched.