### PR TITLE
fix(drizzle-neon): Use polyfills

### DIFF
--- a/templates/drizzle-neondb-sample/vulcan.config.js
+++ b/templates/drizzle-neondb-sample/vulcan.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  useNodePolyfills: true
+};


### PR DESCRIPTION
Add configuration to use this polyfills, to prevent compatibility problems with different versions of the Azion Cells.