### PR TITLE
fix: update preset from 'next' to 'opennextjs' in template info files

### DIFF
--- a/templates/opennextjs/nextjs-ai-chatbot/info.json
+++ b/templates/opennextjs/nextjs-ai-chatbot/info.json
@@ -1,7 +1,7 @@
 {
   "name": "Next.js AI Chatbot",
   "message": "A full-featured AI Chatbot site powered by Next.js and AI SDK",
-  "preset": "next",
+  "preset": "opennextjs",
   "mode": "compute",
   "path": "/nextjs-ai-chatbot"
 }

--- a/templates/opennextjs/nextjs-boilerplate/info.json
+++ b/templates/opennextjs/nextjs-boilerplate/info.json
@@ -1,7 +1,7 @@
 {
   "name": "Next.js Boilerplate",
   "message": "Next.js Boilerplate",
-  "preset": "next",
+  "preset": "opennextjs",
   "mode": "compute",
   "path": "/nextjs-boilerplate"
 }

--- a/templates/opennextjs/nextjs-commerce-shopify/info.json
+++ b/templates/opennextjs/nextjs-commerce-shopify/info.json
@@ -1,7 +1,7 @@
 {
   "name": "Next.js Commerce with Shopify",
   "message": "A full-featured e-commerce site powered by Next.js and Shopify",
-  "preset": "next",
+  "preset": "opennextjs",
   "mode": "compute",
   "path": "/nextjs-commerce-shopify"
 }

--- a/templates/opennextjs/nextjs-platforms/info.json
+++ b/templates/opennextjs/nextjs-platforms/info.json
@@ -1,7 +1,7 @@
 {
   "name": "Next.js Multi-Tenant",
   "message": "A production-ready example of a multi-tenant application built with Next.js 15, featuring custom subdomains for each tenant.",
-  "preset": "next",
+  "preset": "opennextjs",
   "mode": "compute",
   "path": "/nextjs-platforms"
 }


### PR DESCRIPTION
This pull request updates the template configuration for several Next.js-based projects to use the `opennextjs` preset instead of the default `next` preset. This change ensures that all templates are consistently configured to leverage the features and settings provided by the `opennextjs` preset.

Template configuration updates:

* Updated the `preset` field from `next` to `opennextjs` in `nextjs-ai-chatbot/info.json` to align with the new template standard.
* Updated the `preset` field from `next` to `opennextjs` in `nextjs-boilerplate/info.json` for consistency.
* Updated the `preset` field from `next` to `opennextjs` in `nextjs-commerce-shopify/info.json` to ensure proper configuration.
* Updated the `preset` field from `next` to `opennextjs` in `nextjs-platforms/info.json` for standardized setup.