### PR TITLE
fix(reactjs-boilerplate): pin typescript to ^4.9.5

### DIFF
--- a/templates/react/reactjs-boilerplate/package.json
+++ b/templates/react/reactjs-boilerplate/package.json
@@ -18,6 +18,9 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "devDependencies": {
+    "typescript": "^4.9.5"
+  },
   "eslintConfig": {
     "extends": [
       "react-app",


### PR DESCRIPTION
This pull request adds TypeScript as a development dependency to the project. This will allow you to use TypeScript for type checking and development tooling without affecting the production build.

* Added `typescript` version `^4.9.5` to the `devDependencies` section in `package.json`.